### PR TITLE
修复4月17日打卡失败：服务异常(7)

### DIFF
--- a/wzxy-dailyreport.py
+++ b/wzxy-dailyreport.py
@@ -3,6 +3,11 @@ import requests
 import json
 import os
 import utils
+import time
+import hashlib
+sign_time = int(round(time.time() * 1000)) #13位
+content = f"{os.environ['WZXY_PROVINCE']}_{sign_time}_{os.environ['WZXY_CITY']}" 
+signature = hashlib.sha256(content.encode('utf-8')).hexdigest()
 from urllib.parse import urlencode
 
 
@@ -137,7 +142,10 @@ class WoZaiXiaoYuanPuncher:
             "street": os.environ['WZXY_STREET'],
             "myArea": "",
             "areacode": "",
-            "userId": ""
+            "userId": "",
+            "city_code": os.environ.get('WZXY_CITYCODE'),
+            "timestampHeader": sign_time,
+            "signatureHeader": signature
         }
         data = urlencode(sign_data)
         self.session = requests.session()    


### PR DESCRIPTION
参考自大佬https://www.sizau.com/a/wzxy-signature.html

请添加使用说明：

需要在Setings 进入 Environment ，打开自己建立的WZXY_CONFIG_01，（在 “Environment Secrets” 一栏中）点击 Add Secret 按钮，新建以下 Secret，并填写对应 Value 值

CITYCODE：打卡该项目时所提交位置信息的市代码，对应抓包信息中的 “CITY_CODE”。不会抓包可参考该网列举的城市代码值，仅供参考https://www.jianshu.com/p/89a56dce79f5

如：上海对应的城市代码为156310100，将156310100这串数字填入CITYCODE的Value